### PR TITLE
respect 'start' argument

### DIFF
--- a/virtualOS/Model/MainViewModel.swift
+++ b/virtualOS/Model/MainViewModel.swift
@@ -72,6 +72,11 @@ final class MainViewModel: NSObject, ObservableObject {
         readParametersFromDisk()
         loadLicenseInformationFromBundle()
         moveFilesAfterUpdate()
+        for arg in CommandLine.arguments {
+            if (arg == "start") {
+                start()
+            }
+        }
     }
 
     func statusButtonPressed() {


### PR DESCRIPTION
auto-start (with latest settings), when `start` parameter is specified, e.g.
````
open  /Applications/virtualOS.app --args start
````
See https://github.com/yep/virtualOS/issues/22