### PR TITLE
Store mac address in parameters

### DIFF
--- a/virtualOS/Model/VirtualMac.swift
+++ b/virtualOS/Model/VirtualMac.swift
@@ -27,6 +27,7 @@ final class VirtualMac: ObservableObject {
             screenHeight      = try container.decode(Int.self, forKey: .screenHeight)
             pixelsPerInch     = try container.decode(Int.self, forKey: .pixelsPerInch)
             microphoneEnabled = try container.decode(Bool.self, forKey: .microphoneEnabled)
+            macAddress        = try container.decodeIfPresent(String.self, forKey: .macAddress) ?? VZMACAddress.randomLocallyAdministered().string
         }
         
         var cpuCount = 1
@@ -41,6 +42,7 @@ final class VirtualMac: ObservableObject {
         var screenHeight = 900
         var pixelsPerInch = 250
         var microphoneEnabled = false
+        var macAddress = VZMACAddress.randomLocallyAdministered().string
     }
 
     typealias InstallCompletionHander = (String?, VZVirtualMachine?) -> Void    

--- a/virtualOS/Model/VirtualMacConfiguration.swift
+++ b/virtualOS/Model/VirtualMacConfiguration.swift
@@ -57,7 +57,7 @@ final class VirtualMacConfiguration: VZVirtualMachineConfiguration {
         configureAudioDevice(parameters: parameters)
         configureGraphicsDevice(parameters: parameters)
         configureStorageDevice(parameters: parameters)
-        configureNetworkDevices()
+        configureNetworkDevices(parameters: parameters)
     }
 
     // MARK: - Private
@@ -89,10 +89,11 @@ final class VirtualMacConfiguration: VZVirtualMachineConfiguration {
         return true // success
     }
 
-    fileprivate func configureNetworkDevices() {
+    fileprivate func configureNetworkDevices(parameters: VirtualMac.Parameters) {
         let networkDevice = VZVirtioNetworkDeviceConfiguration()
         let networkAttachment = VZNATNetworkDeviceAttachment()
         networkDevice.attachment = networkAttachment
+        networkDevice.macAddress = VZMACAddress(string: parameters.macAddress) ?? .randomLocallyAdministered()
         networkDevices = [networkDevice]
     }
 


### PR DESCRIPTION
Since the mac address of the virtual interface is not persisted between starts of the app/machine, every time a new/unique `random locally administered` mac address is used. Hence, the host system always assigns a new IP address via DHCP. Check the file `/var/db/dhcpd_leases` on the host OS.

With this PR the address is stored in the parameters.