### PR TITLE
Support custom restore images directory path

### DIFF
--- a/virtualOS.xcodeproj/project.pbxproj
+++ b/virtualOS.xcodeproj/project.pbxproj
@@ -273,7 +273,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = virtualOS/Resources/virtualOS.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 28;
@@ -285,9 +284,11 @@
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = virtualOS/Resources/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMainStoryboardFile = Main;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Please allow microphone access to use audio input in the virtual machine.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -309,7 +310,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = virtualOS/Resources/virtualOS.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 28;
@@ -321,9 +321,11 @@
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = virtualOS/Resources/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMainStoryboardFile = Main;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Please allow microphone access to use audio input in the virtual machine.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/virtualOS/Extension/URL+Paths.swift
+++ b/virtualOS/Extension/URL+Paths.swift
@@ -10,14 +10,25 @@ extension URL {
     static let bundleName       = "virtualOS.bundle/"
     static let restoreImageName = "RestoreImage.ipsw"
 
+    /// The `Documents` directory URL
     static var baseURL: URL {
         return URL(fileURLWithPath: basePath)
     }
     static var defaultRestoreImageURL: URL {
+        if let path = UserDefaults.standard.restoreImagesDirectory {
+            return URL(fileURLWithPath: path + "/" + restoreImageName)
+        }
         return URL(fileURLWithPath: basePath + "/" + restoreImageName)
     }
     static var tmpURL: URL {
-        return URL(fileURLWithPath: NSHomeDirectory() + "/tmp")
+        return URL.temporaryDirectory.appendingPathComponent("data")
+    }
+    /// The restore images directory URL (custom or the default)
+    static var restoreImagesDirectoryURL: URL {
+        if let path = UserDefaults.standard.restoreImagesDirectory {
+            return URL(fileURLWithPath: path)
+        }
+        return baseURL
     }
     var auxiliaryStorageURL: URL {
         return self.appending(path: "AuxiliaryStorage")

--- a/virtualOS/Extension/UserDefaults+Settings.swift
+++ b/virtualOS/Extension/UserDefaults+Settings.swift
@@ -18,7 +18,7 @@ extension UserDefaults {
             if object(forKey: Self.diskSizeKey) != nil {
                 return integer(forKey: Self.diskSizeKey)
             }
-            return 30 // default value
+            return Constants.defaultDiskImageSize
         }
         set {
             set(newValue, forKey: Self.diskSizeKey)

--- a/virtualOS/Extension/UserDefaults+Settings.swift
+++ b/virtualOS/Extension/UserDefaults+Settings.swift
@@ -11,7 +11,9 @@ import Foundation
 extension UserDefaults {
     fileprivate static let diskSizeKey                  = "diskSize"
     fileprivate static let vmFilesDirectoryKey          = "vmFilesDirectoryKey"
-    fileprivate static let vmFilesDirectoryBookmarkData = "vmFilesDirectoryBookmarkData"
+    fileprivate static let vmFilesDirectoryBookmarkDataKey = "vmFilesDirectoryBookmarkData"
+    fileprivate static let restoreImagesDirectoryKey     = "restoreImagesDirectoryKey"
+    fileprivate static let restoreImagesDirectoryBookmarkDataKey = "restoreImagesDirectoryBookmarkData"
 
     var diskSize: Int {
         get {
@@ -38,10 +40,31 @@ extension UserDefaults {
 
     var vmFilesDirectoryBookmarkData: Data? {
         get {
-            return data(forKey: Self.vmFilesDirectoryBookmarkData)
+            return data(forKey: Self.vmFilesDirectoryBookmarkDataKey)
         }
         set {
-            set(newValue, forKey: Self.vmFilesDirectoryBookmarkData)
+            set(newValue, forKey: Self.vmFilesDirectoryBookmarkDataKey)
+            synchronize()
+        }
+    }
+
+    /// Returns the Restore Images directory selected by the user
+    var restoreImagesDirectory: String? {
+        get {
+            return string(forKey: Self.restoreImagesDirectoryKey)
+        }
+        set {
+            set(newValue, forKey: Self.restoreImagesDirectoryKey)
+            synchronize()
+        }
+    }
+
+    var restoreImagesDirectoryBookmarkData: Data? {
+        get {
+            return data(forKey: Self.restoreImagesDirectoryBookmarkDataKey)
+        }
+        set {
+            set(newValue, forKey: Self.restoreImagesDirectoryBookmarkDataKey)
             synchronize()
         }
     }

--- a/virtualOS/Model/Bookmark.swift
+++ b/virtualOS/Model/Bookmark.swift
@@ -29,16 +29,15 @@ struct Bookmark {
             if let previousURL = accessedURLs[path],
                previousURL != bookmarkURL
             {
-                previousURL.stopAccessingSecurityScopedResource()
-                Logger.shared.log(level: .default, "stop accessing security scoped resource (1): \(previousURL.path())")
+                stopAccess(url: previousURL)
             }
             
             if accessedURLs[path] != bookmarkURL {
                 // resource not already accessed, start access
                 if bookmarkURL.startAccessingSecurityScopedResource() {
-                    Logger.shared.log(level: .default, "start accessing security scoped resource: \(path)")
+                    // Logger.shared.log(level: .info, "start accessing security scoped resource: \(path)")
                 } else {
-                    Logger.shared.log(level: .default, "stop accessing security scoped resource failed")
+                    // Logger.shared.log(level: .info, "stop accessing security scoped resource failed")
                 }
                 accessedURLs[path] = bookmarkURL
             }
@@ -50,14 +49,14 @@ struct Bookmark {
     
     static func stopAccess(url: URL) {
         url.stopAccessingSecurityScopedResource()
-        Logger.shared.log(level: .default, "stop accessing security scoped resource (2): \(url.path)")
+        // Logger.shared.log(level: .info, "stop accessing security scoped resource (1): \(url.path)")
         Self.accessedURLs[url.path] = nil
     }
     
     static func stopAllAccess() {
         for (urlString, accessedURL) in accessedURLs {
             accessedURL.stopAccessingSecurityScopedResource()
-            Logger.shared.log(level: .default, "stop accessing security scoped resource (3): \(urlString)")
+            Logger.shared.log(level: .info, "stop accessing security scoped resource (2): \(urlString)")
         }
         Self.accessedURLs = [:]
     }

--- a/virtualOS/Model/Bookmark.swift
+++ b/virtualOS/Model/Bookmark.swift
@@ -60,4 +60,18 @@ struct Bookmark {
         }
         Self.accessedURLs = [:]
     }
+    
+    @discardableResult
+    static func startRestoreImagesDirectoryAccess() -> Bool {
+        guard let filesDirectoryString = UserDefaults.standard.restoreImagesDirectory ?? UserDefaults.standard.vmFilesDirectory else {
+            return false
+        }
+        
+        // grant access
+        let bookmarkData = UserDefaults.standard.restoreImagesDirectoryBookmarkData ?? UserDefaults.standard.vmFilesDirectoryBookmarkData
+        if Bookmark.startAccess(bookmarkData: bookmarkData, for: filesDirectoryString) == nil {
+            return false
+        }
+        return true
+    }
 }

--- a/virtualOS/Model/Constants.swift
+++ b/virtualOS/Model/Constants.swift
@@ -12,7 +12,7 @@ struct Constants {
     static let restoreImageNameLatest = "latest"
     static let selectedRestoreImage   = "selectedRestoreImage"
     static let restoreImageNameSelectedNotification = Notification.Name("restoreImageSelected")
-    static let didChangeVMLocationNotification      = Notification.Name("didChangeVMLocation")
+    static let didChangeAppSettingsNotification   = Notification.Name("didChangeAppSettings")
     static let defaultDiskImageSize   = 30
     
     enum NetworkType: String, CaseIterable, Codable {

--- a/virtualOS/Model/Constants.swift
+++ b/virtualOS/Model/Constants.swift
@@ -13,4 +13,10 @@ struct Constants {
     static let selectedRestoreImage   = "selectedRestoreImage"
     static let restoreImageNameSelectedNotification = Notification.Name("restoreImageSelected")
     static let didChangeVMLocationNotification      = Notification.Name("didChangeVMLocation")
+    static let defaultDiskImageSize   = 30
+    
+    enum NetworkType: String, CaseIterable, Codable {
+        case nat
+        case bridged
+    }
 }

--- a/virtualOS/Model/Enums.swift
+++ b/virtualOS/Model/Enums.swift
@@ -1,0 +1,12 @@
+//
+//  Enums.swift
+//  virtualOS
+//
+//  Created by Jahn Bertsch.
+//  Licensed under the Apache License, see LICENSE file.
+//
+
+enum NetworkType: String, CaseIterable, Codable {
+    case NAT
+    case Bridge
+}

--- a/virtualOS/Model/FileModel.swift
+++ b/virtualOS/Model/FileModel.swift
@@ -10,6 +10,14 @@ import Foundation
 import OSLog
 
 struct FileModel {
+    private var restoreImagesDirectoryURL: URL? {
+        if let path = UserDefaults.standard.restoreImagesDirectory as String? {
+            return URL(fileURLWithPath: path)
+        }
+        
+        return nil
+    }
+    
     func getVMBundles() -> [VMBundle] {
         var result: [VMBundle] = []
         var hardDiskDirectoryURL = URL.baseURL
@@ -29,11 +37,13 @@ struct FileModel {
         return result
     }
     
+    /// Returns the names of the restore images in the images directory
+    /// - Performs directory scan each time
     func getRestoreImages() -> [String] {
         var result: [String] = []
-        let vmFilesDirectory = FileModel.createVMFilesDirectory()
+        let imageFilesDirectory = restoreImagesDirectoryURL ?? FileModel.createVMFilesDirectory()
                 
-        if let urls = try? FileManager.default.contentsOfDirectory(at: vmFilesDirectory, includingPropertiesForKeys: nil, options: []) {
+        if let urls = try? FileManager.default.contentsOfDirectory(at: imageFilesDirectory, includingPropertiesForKeys: nil, options: []) {
             for url in urls {
                 if url.lastPathComponent.hasSuffix("ipsw") {
                     result.append(url.lastPathComponent)

--- a/virtualOS/Model/ParametersViewDataSource.swift
+++ b/virtualOS/Model/ParametersViewDataSource.swift
@@ -15,7 +15,7 @@ final class ParametersViewDataSource: NSObject, NSOutlineViewDataSource {
     
     func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
         if mainViewModel?.vmParameters != nil {
-            return 5
+            return 3
         } else {
             return 0
         }
@@ -25,15 +25,11 @@ final class ParametersViewDataSource: NSObject, NSOutlineViewDataSource {
         if let vmParameters = mainViewModel?.vmParameters {
             switch index {
             case 0:
-                return ["CPU Count", "\(vmParameters.cpuCount)"]
-            case 1:
-                return ["Memory Size (GB)", "\(vmParameters.memorySizeInGB)"]
-            case 2:
                 return ["Disk Size (GB)", "\(vmParameters.diskSizeInGB)"]
-            case 3:
+            case 1:
                 let sharedFolderString = sharedFolderInfo(vmParameters: vmParameters)
                 return ["Shared Folder", sharedFolderString]
-            case 4:
+            case 2:
                 return ["Version", "\(vmParameters.version)"]
             default:
                 return ["index \(index)", "value \(index)"]

--- a/virtualOS/Resources/Base.lproj/Main.storyboard
+++ b/virtualOS/Resources/Base.lproj/Main.storyboard
@@ -746,17 +746,17 @@
             <objects>
                 <viewController title="virtualOS" storyboardIdentifier="MainViewController" id="XfG-lQ-9wD" customClass="MainViewController" customModule="virtualOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="644" height="290"/>
+                        <rect key="frame" x="0.0" y="0.0" width="644" height="343"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView focusRingType="none" autohidesScrollers="YES" horizontalLineScroll="27" horizontalPageScroll="10" verticalLineScroll="27" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bLz-9W-E0Q">
-                                <rect key="frame" x="20" y="20" width="214" height="250"/>
+                                <rect key="frame" x="20" y="20" width="214" height="303"/>
                                 <clipView key="contentView" focusRingType="none" id="dRS-R9-JhK">
-                                    <rect key="frame" x="1" y="1" width="212" height="248"/>
+                                    <rect key="frame" x="1" y="1" width="212" height="301"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" tableStyle="plain" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="18" id="SLV-LP-8yS">
-                                            <rect key="frame" x="0.0" y="0.0" width="212" height="248"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="212" height="301"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="9"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -791,13 +791,13 @@
                                 </scroller>
                             </scrollView>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xYa-aB-2n1">
-                                <rect key="frame" x="238" y="20" width="386" height="160"/>
+                                <rect key="frame" x="238" y="20" width="386" height="151"/>
                                 <clipView key="contentView" id="NKO-Vj-ex1">
-                                    <rect key="frame" x="1" y="1" width="384" height="158"/>
+                                    <rect key="frame" x="1" y="1" width="384" height="149"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" headerView="Up0-CN-Hwh" viewBased="YES" indentationPerLevel="13" outlineTableColumn="twK-Ii-IWq" id="FAz-DU-FNt">
-                                            <rect key="frame" x="0.0" y="0.0" width="384" height="130"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="384" height="121"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -883,7 +883,7 @@
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="150" id="HlI-kp-iqx"/>
                                 </constraints>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Teu-XY-Qhj">
-                                    <rect key="frame" x="1" y="170" width="384" height="17"/>
+                                    <rect key="frame" x="1" y="133" width="384" height="17"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="cyE-aw-R3w">
@@ -896,7 +896,7 @@
                                 </tableHeaderView>
                             </scrollView>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2ay-GK-UXb">
-                                <rect key="frame" x="238" y="246" width="386" height="24"/>
+                                <rect key="frame" x="238" y="299" width="386" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="380" id="2NP-zs-Qjw"/>
                                 </constraints>
@@ -907,21 +907,21 @@
                                 </textFieldCell>
                             </textField>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aid-tx-60f">
-                                <rect key="frame" x="344" y="222" width="280" height="16"/>
+                                <rect key="frame" x="344" y="275" width="280" height="16"/>
                                 <sliderCell key="cell" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" allowsTickMarkValuesOnly="YES" sliderType="linear" id="dGd-mC-Nbm">
                                     <font key="font" size="12" name="Helvetica"/>
                                 </sliderCell>
                             </slider>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vjp-OJ-ccY">
-                                <rect key="frame" x="344" y="198" width="280" height="16"/>
+                                <rect key="frame" x="344" y="251" width="280" height="16"/>
                                 <sliderCell key="cell" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" allowsTickMarkValuesOnly="YES" sliderType="linear" id="cKs-Fo-lSs">
                                     <font key="font" size="12" name="Helvetica"/>
                                 </sliderCell>
                             </slider>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oMc-Ex-Id4">
-                                <rect key="frame" x="236" y="221" width="102" height="16"/>
+                                <rect key="frame" x="240" y="274" width="98" height="16"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="98" id="iSa-om-WSH"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="94" id="iSa-om-WSH"/>
                                 </constraints>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="CPU Count: 10" id="Ykf-ZA-cgR">
                                     <font key="font" metaFont="system"/>
@@ -930,9 +930,9 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BnL-6C-wN5">
-                                <rect key="frame" x="236" y="194" width="102" height="16"/>
+                                <rect key="frame" x="240" y="247" width="98" height="16"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="98" id="Fbl-aQ-uRR"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="94" id="Fbl-aQ-uRR"/>
                                 </constraints>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="RAM (GB): 10" id="711-FZ-kdB">
                                     <font key="font" metaFont="system"/>
@@ -940,26 +940,100 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="hsn-DU-AzG">
+                                <rect key="frame" x="344" y="211" width="54" height="24"/>
+                                <connections>
+                                    <action selector="microphoneSwitchToggled:" target="XfG-lQ-9wD" id="adD-BW-3aR"/>
+                                </connections>
+                            </switch>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7dR-C2-a9L">
+                                <rect key="frame" x="240" y="183" width="98" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="94" id="ted-zM-JI6"/>
+                                </constraints>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Network" id="H9M-U3-6tS">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7F6-2u-9dP">
+                                <rect key="frame" x="344" y="179" width="85" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="NAT" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="MGt-ay-YSy" id="dVi-BP-SDE">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="message"/>
+                                    <menu key="menu" id="0m0-x8-G1I">
+                                        <items>
+                                            <menuItem title="NAT" state="on" id="MGt-ay-YSy"/>
+                                            <menuItem title="Bridge" id="26Y-g2-E4B"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="networkPopUpChanged:" target="XfG-lQ-9wD" id="7eZ-jW-gc2"/>
+                                </connections>
+                            </popUpButton>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pKq-QZ-fhF">
+                                <rect key="frame" x="437" y="179" width="99" height="24"/>
+                                <popUpButtonCell key="cell" type="push" title="Interface" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="9wg-ze-ntB" id="O51-UG-oXN">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="message"/>
+                                    <menu key="menu" id="ixf-qp-X8j">
+                                        <items>
+                                            <menuItem title="Interface" state="on" id="9wg-ze-ntB"/>
+                                        </items>
+                                    </menu>
+                                    <connections>
+                                        <action selector="networkBridgeInterfacePopUpChanged:" target="XfG-lQ-9wD" id="Nef-rE-MsG"/>
+                                    </connections>
+                                </popUpButtonCell>
+                            </popUpButton>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I5p-V8-Rmw">
+                                <rect key="frame" x="240" y="215" width="98" height="16"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="94" id="fHt-Vs-Uzx"/>
+                                </constraints>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Audio Input" id="Ep9-C1-MLc">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <connections>
+                                        <action selector="makeTextWritingDirectionNatural:" target="m2S-Jp-Qdl" id="LI0-8g-Kfr"/>
+                                    </connections>
+                                </textFieldCell>
+                            </textField>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="7dR-C2-a9L" firstAttribute="top" secondItem="I5p-V8-Rmw" secondAttribute="bottom" constant="16" id="05K-6T-lh6"/>
+                            <constraint firstItem="xYa-aB-2n1" firstAttribute="firstBaseline" secondItem="7F6-2u-9dP" secondAttribute="baseline" constant="15" id="0J6-IK-Oga"/>
                             <constraint firstItem="vjp-OJ-ccY" firstAttribute="top" secondItem="aid-tx-60f" secondAttribute="bottom" constant="8" symbolic="YES" id="2Br-Vf-Hgs"/>
                             <constraint firstItem="bLz-9W-E0Q" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" symbolic="YES" id="59D-Tw-8S0"/>
+                            <constraint firstItem="I5p-V8-Rmw" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="9" id="9x3-Z6-AE9"/>
+                            <constraint firstItem="pKq-QZ-fhF" firstAttribute="leading" secondItem="7F6-2u-9dP" secondAttribute="trailing" constant="8" symbolic="YES" id="A90-Il-Wls"/>
                             <constraint firstItem="BnL-6C-wN5" firstAttribute="top" secondItem="oMc-Ex-Id4" secondAttribute="bottom" constant="11" id="Cee-kV-8AV"/>
                             <constraint firstAttribute="trailing" secondItem="aid-tx-60f" secondAttribute="trailing" constant="20" symbolic="YES" id="FwA-Kn-sfo"/>
+                            <constraint firstItem="pKq-QZ-fhF" firstAttribute="centerY" secondItem="7dR-C2-a9L" secondAttribute="centerY" id="G5B-7s-VCU"/>
                             <constraint firstItem="2ay-GK-UXb" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" symbolic="YES" id="HZG-ZK-k6X"/>
                             <constraint firstItem="aid-tx-60f" firstAttribute="top" secondItem="2ay-GK-UXb" secondAttribute="bottom" constant="8" symbolic="YES" id="Hd4-uS-bSq"/>
-                            <constraint firstItem="BnL-6C-wN5" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="5" id="Hhs-Zu-Tqf"/>
+                            <constraint firstItem="BnL-6C-wN5" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="9" id="Hhs-Zu-Tqf"/>
                             <constraint firstItem="2ay-GK-UXb" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="5" id="IBL-w0-c2S"/>
                             <constraint firstItem="bLz-9W-E0Q" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="KWQ-fQ-SLQ"/>
+                            <constraint firstItem="Up0-CN-Hwh" firstAttribute="top" secondItem="7F6-2u-9dP" secondAttribute="bottom" constant="18" id="NSk-g9-Z6B"/>
                             <constraint firstItem="vjp-OJ-ccY" firstAttribute="leading" secondItem="BnL-6C-wN5" secondAttribute="trailing" constant="8" symbolic="YES" id="Q9m-il-3Zc"/>
                             <constraint firstAttribute="trailing" secondItem="2ay-GK-UXb" secondAttribute="trailing" constant="20" symbolic="YES" id="S4Y-p5-A3O"/>
-                            <constraint firstItem="xYa-aB-2n1" firstAttribute="top" secondItem="BnL-6C-wN5" secondAttribute="bottom" constant="14" id="SdI-LZ-S2P"/>
-                            <constraint firstItem="oMc-Ex-Id4" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="5" id="UQ1-Ca-uCx"/>
+                            <constraint firstItem="oMc-Ex-Id4" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="9" id="UQ1-Ca-uCx"/>
                             <constraint firstItem="bLz-9W-E0Q" firstAttribute="width" secondItem="2ay-GK-UXb" secondAttribute="height" multiplier="187:21" id="XkA-tb-7EO"/>
                             <constraint firstAttribute="trailing" secondItem="xYa-aB-2n1" secondAttribute="trailing" constant="20" symbolic="YES" id="YaT-Pz-lnl"/>
+                            <constraint firstItem="7F6-2u-9dP" firstAttribute="leading" secondItem="7dR-C2-a9L" secondAttribute="trailing" constant="8" symbolic="YES" id="cab-jj-bZS"/>
                             <constraint firstAttribute="trailing" secondItem="vjp-OJ-ccY" secondAttribute="trailing" constant="20" symbolic="YES" id="fnq-Ye-IrA"/>
+                            <constraint firstItem="I5p-V8-Rmw" firstAttribute="top" secondItem="BnL-6C-wN5" secondAttribute="bottom" constant="16" id="h4w-ua-Wg6"/>
                             <constraint firstAttribute="bottom" secondItem="bLz-9W-E0Q" secondAttribute="bottom" constant="20" symbolic="YES" id="mEf-HR-tGY"/>
+                            <constraint firstItem="hsn-DU-AzG" firstAttribute="centerY" secondItem="I5p-V8-Rmw" secondAttribute="centerY" id="oAz-Vk-DNW"/>
+                            <constraint firstItem="7dR-C2-a9L" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="9" id="p1e-3P-qgU"/>
                             <constraint firstItem="xYa-aB-2n1" firstAttribute="leading" secondItem="SLV-LP-8yS" secondAttribute="trailing" constant="5" id="p59-gV-lo4"/>
+                            <constraint firstItem="7F6-2u-9dP" firstAttribute="centerY" secondItem="7dR-C2-a9L" secondAttribute="centerY" id="qOi-hX-1aF"/>
+                            <constraint firstItem="7F6-2u-9dP" firstAttribute="centerY" secondItem="7dR-C2-a9L" secondAttribute="centerY" id="sIS-FG-FHy"/>
+                            <constraint firstItem="hsn-DU-AzG" firstAttribute="leading" secondItem="I5p-V8-Rmw" secondAttribute="trailing" constant="8" symbolic="YES" id="sJT-bJ-gK5"/>
                             <constraint firstAttribute="bottom" secondItem="xYa-aB-2n1" secondAttribute="bottom" constant="20" symbolic="YES" id="uM4-MH-Ha4"/>
                             <constraint firstItem="oMc-Ex-Id4" firstAttribute="top" secondItem="aid-tx-60f" secondAttribute="top" constant="1" id="ve4-3k-h9o"/>
                             <constraint firstItem="aid-tx-60f" firstAttribute="leading" secondItem="oMc-Ex-Id4" secondAttribute="trailing" constant="8" symbolic="YES" id="vug-C1-93C"/>
@@ -968,6 +1042,9 @@
                     <connections>
                         <outlet property="cpuCountLabel" destination="oMc-Ex-Id4" id="PMN-cw-wug"/>
                         <outlet property="cpuCountSlider" destination="aid-tx-60f" id="6ke-q0-mFp"/>
+                        <outlet property="microphoneSwitch" destination="hsn-DU-AzG" id="8m3-Ah-nYa"/>
+                        <outlet property="networkBridgePopUpButton" destination="pKq-QZ-fhF" id="gby-2o-SFK"/>
+                        <outlet property="networkPopUpButton" destination="7F6-2u-9dP" id="Spd-km-LAe"/>
                         <outlet property="parameterOutlineView" destination="FAz-DU-FNt" id="PLq-a8-6EM"/>
                         <outlet property="ramLabel" destination="BnL-6C-wN5" id="4Bf-ty-vRr"/>
                         <outlet property="ramSlider" destination="vjp-OJ-ccY" id="DD5-nf-ntM"/>
@@ -977,7 +1054,7 @@
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="102" y="1022.5"/>
+            <point key="canvasLocation" x="102" y="1021.5"/>
         </scene>
         <!--Settings-->
         <scene sceneID="Qt9-N3-HhJ">

--- a/virtualOS/Resources/Base.lproj/Main.storyboard
+++ b/virtualOS/Resources/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                                         <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
                                         <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
                                             <connections>
-                                                <segue destination="Xqe-mX-POt" kind="show" id="ogJ-Ly-ARq"/>
+                                                <segue destination="aLw-hb-N3z" kind="show" id="Q4w-wd-nDi"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
@@ -1056,90 +1056,6 @@
             </objects>
             <point key="canvasLocation" x="102" y="1021.5"/>
         </scene>
-        <!--Settings-->
-        <scene sceneID="Qt9-N3-HhJ">
-            <objects>
-                <viewController title="Settings" id="Xqe-mX-POt" customClass="SettingsViewController" customModule="virtualOS" customModuleProvider="target" sceneMemberID="viewController">
-                    <customView key="view" id="yG5-4w-bTo">
-                        <rect key="frame" x="0.0" y="0.0" width="463" height="102"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <subviews>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oir-YL-keR">
-                                <rect key="frame" x="330" y="61" width="113" height="24"/>
-                                <buttonCell key="cell" type="push" title="Show in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="AbN-et-pKv">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="showInFinderButtonPressed:" target="Xqe-mX-POt" id="FJp-qw-o7x"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yrx-BG-l55">
-                                <rect key="frame" x="143" y="61" width="104" height="21"/>
-                                <buttonCell key="cell" type="push" title="Select Folder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iTn-kK-dDs">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="selectFolderButtonPressed:" target="Xqe-mX-POt" id="f9G-Wd-fdl"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1JM-2f-1me">
-                                <rect key="frame" x="259" y="61" width="59" height="24"/>
-                                <buttonCell key="cell" type="push" title="Reset" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="mPJ-qR-vtN">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="resetButtonPressed:" target="Xqe-mX-POt" id="Kwk-8L-7VD"/>
-                                </connections>
-                            </button>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="N5x-TP-ag2">
-                                <rect key="frame" x="18" y="20" width="427" height="36"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="36" id="2K4-dO-x7Q"/>
-                                    <constraint firstAttribute="width" constant="423" id="M3j-3A-oov"/>
-                                </constraints>
-                                <textFieldCell key="cell" title="VM Files URL" id="ow8-Hj-vT5">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eeq-an-X5s">
-                                <rect key="frame" x="18" y="65" width="56" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="VM Files" id="fDk-2c-wQ3">
-                                    <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="N5x-TP-ag2" firstAttribute="top" secondItem="eeq-an-X5s" secondAttribute="bottom" constant="9" id="0tz-CN-WyT"/>
-                            <constraint firstItem="eeq-an-X5s" firstAttribute="leading" secondItem="yG5-4w-bTo" secondAttribute="leading" constant="20" symbolic="YES" id="6ws-ha-Gys"/>
-                            <constraint firstItem="yrx-BG-l55" firstAttribute="baseline" secondItem="1JM-2f-1me" secondAttribute="baseline" id="96J-Ws-0eA"/>
-                            <constraint firstItem="1JM-2f-1me" firstAttribute="leading" secondItem="yrx-BG-l55" secondAttribute="trailing" constant="12" symbolic="YES" id="E34-ho-lkF"/>
-                            <constraint firstItem="Oir-YL-keR" firstAttribute="leading" secondItem="1JM-2f-1me" secondAttribute="trailing" constant="12" symbolic="YES" id="Hp5-1g-Qdq"/>
-                            <constraint firstItem="yrx-BG-l55" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="eeq-an-X5s" secondAttribute="trailing" constant="8" symbolic="YES" id="IuO-gg-gHu"/>
-                            <constraint firstItem="1JM-2f-1me" firstAttribute="baseline" secondItem="Oir-YL-keR" secondAttribute="baseline" id="PYo-JK-nrv"/>
-                            <constraint firstItem="Oir-YL-keR" firstAttribute="trailing" secondItem="N5x-TP-ag2" secondAttribute="trailing" id="REA-mb-32E"/>
-                            <constraint firstItem="eeq-an-X5s" firstAttribute="baseline" secondItem="yrx-BG-l55" secondAttribute="baseline" id="TOC-NR-S0Z"/>
-                            <constraint firstItem="eeq-an-X5s" firstAttribute="leading" secondItem="N5x-TP-ag2" secondAttribute="leading" id="kXi-y1-uoz"/>
-                            <constraint firstAttribute="trailing" secondItem="Oir-YL-keR" secondAttribute="trailing" constant="20" symbolic="YES" id="kmW-el-1Uv"/>
-                            <constraint firstItem="yrx-BG-l55" firstAttribute="top" secondItem="yG5-4w-bTo" secondAttribute="top" constant="20" symbolic="YES" id="oAY-GN-eYq"/>
-                            <constraint firstItem="eeq-an-X5s" firstAttribute="top" secondItem="yG5-4w-bTo" secondAttribute="top" constant="21" id="reo-nV-FwY"/>
-                            <constraint firstAttribute="bottom" secondItem="N5x-TP-ag2" secondAttribute="bottom" constant="20" symbolic="YES" id="svA-Vt-bpn"/>
-                        </constraints>
-                    </customView>
-                    <connections>
-                        <outlet property="vmFilesURLLabel" destination="N5x-TP-ag2" id="70K-hx-P8c"/>
-                    </connections>
-                </viewController>
-                <customObject id="jSA-fl-LXp" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="813" y="159"/>
-        </scene>
         <!--VM View-->
         <scene sceneID="7wI-8z-dsV">
             <objects>
@@ -1395,9 +1311,120 @@ Gw
             </objects>
             <point key="canvasLocation" x="1166" y="603"/>
         </scene>
+        <!--Settings-->
+        <scene sceneID="yjJ-6a-VAG">
+            <objects>
+                <viewController title="Settings" showSeguePresentationStyle="single" id="aLw-hb-N3z" customClass="SettingsViewController" customModule="virtualOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <customView key="view" id="InZ-qN-EKZ">
+                        <rect key="frame" x="0.0" y="0.0" width="489" height="213"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <subviews>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pbp-6L-jPK">
+                                <rect key="frame" x="18" y="112" width="409" height="24"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" borderStyle="bezel" title="VM Files" drawsBackground="YES" id="ARJ-eS-R0A">
+                                    <font key="font" textStyle="body" name=".SFNS-Regular"/>
+                                    <color key="textColor" name="placeholderTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pxx-Sf-nlJ">
+                                <rect key="frame" x="18" y="144" width="59" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="VM Files" id="nWF-j1-ULd">
+                                    <font key="font" textStyle="headline" name=".SFNS-Bold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button identifier="vm-files" toolTip="Select folder" tag="1" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSE-Yv-dgh">
+                                <rect key="frame" x="83" y="140" width="63" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Select" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2jY-dD-mEM">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="selectFolderButtonPressed:" target="aLw-hb-N3z" id="8zf-Ec-IZr"/>
+                                </connections>
+                            </button>
+                            <button toolTip="Go to folder" tag="1" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IYB-wT-7Sj">
+                                <rect key="frame" x="435" y="112" width="42" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" bezelStyle="rounded" image="arrow.forward.folder.fill" catalog="system" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="p82-Jl-VDq">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showInFinderButtonPressed:" target="aLw-hb-N3z" id="zzU-U6-Tlr"/>
+                                </connections>
+                            </button>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Yc-TX-gek">
+                                <rect key="frame" x="20" y="32" width="407" height="24"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" borderStyle="bezel" title="Restore Image Files" drawsBackground="YES" id="rD2-zE-zh5">
+                                    <font key="font" textStyle="body" name=".SFNS-Regular"/>
+                                    <color key="textColor" name="placeholderTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pi3-gT-DPc">
+                                <rect key="frame" x="20" y="64" width="131" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Restore Image Files" id="dJB-cl-fiE">
+                                    <font key="font" textStyle="headline" name=".SFNS-Bold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button identifier="restore-images" toolTip="Select folder" tag="2" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BDd-v1-5Nt">
+                                <rect key="frame" x="157" y="60" width="63" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Select" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SAI-Xh-p2b">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="selectFolderButtonPressed:" target="aLw-hb-N3z" id="FSq-zG-fub"/>
+                                </connections>
+                            </button>
+                            <button toolTip="Go to folder" tag="2" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4NX-6p-eSr">
+                                <rect key="frame" x="435" y="32" width="42" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" bezelStyle="rounded" image="arrow.forward.folder.fill" catalog="system" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="xHo-5S-ZaV">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showInFinderButtonPressed:" target="aLw-hb-N3z" id="3LW-pr-cuq"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p1t-PH-mDO">
+                                <rect key="frame" x="418" y="169" width="59" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Reset" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="uBB-eI-pFn">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="resetButtonPressed:" target="aLw-hb-N3z" id="1h9-xE-r9H"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </customView>
+                    <connections>
+                        <outlet property="restoreImageFilesURLLabel" destination="6Yc-TX-gek" id="oVP-BW-YT3"/>
+                        <outlet property="vmFilesURLLabel" destination="pbp-6L-jPK" id="br8-2j-q3S"/>
+                    </connections>
+                </viewController>
+                <customObject id="lM4-b3-aBV" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="860" y="160"/>
+        </scene>
     </scenes>
     <resources>
         <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="arrow.forward.folder.fill" catalog="system" width="18" height="14"/>
         <image name="folder.fill" catalog="system" width="18" height="14"/>
         <image name="play.fill" catalog="system" width="12" height="13"/>
         <image name="trash.fill" catalog="system" width="15" height="17"/>

--- a/virtualOS/Resources/virtualOS.entitlements
+++ b/virtualOS/Resources/virtualOS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.virtualization</key>
 	<true/>
 </dict>

--- a/virtualOS/RestoreImage/RestoreImageDownload.swift
+++ b/virtualOS/RestoreImage/RestoreImageDownload.swift
@@ -44,12 +44,28 @@ final class RestoreImageDownload {
     
     // MARK: - Private
     
+    fileprivate func progressDone(error: Error?) {
+        delegate?.progress(100, progressString: "Done")
+        delegate?.done(error: error)
+    }
+    
     fileprivate func download(restoreImage: VZMacOSRestoreImage) {
         Logger.shared.log(level: .default, "downloading restore image for \(restoreImage.operatingSystemVersionString)")
 
-        let downloadTask = URLSession.shared.downloadTask(with: restoreImage.url) { localURL, response, error in
+        var targetURL: URL? = nil
+        if let filesDirectoryString = UserDefaults.standard.restoreImagesDirectory ?? UserDefaults.standard.vmFilesDirectory {
+            targetURL = createRestoreImageURL(directoryString: filesDirectoryString)
+            
+            // grant access for the restore images path
+            guard Bookmark.startRestoreImagesDirectoryAccess() else {
+                Logger.shared.warning("Could not start accessing bookmark \(filesDirectoryString)")
+                return
+            }
+        }
+        
+        let downloadTask = URLSession.shared.downloadTask(with: restoreImage.url) { tempURL, response, error in
             self.downloading = false
-            self.downloadFinished(localURL: localURL, error: error)
+            self.downloadFinished(tempURL: tempURL, restoreImageURL: targetURL, error: error)
         }
         observation = downloadTask.progress.observe(\.fractionCompleted) { _, _ in }
         downloadTask.resume()
@@ -57,6 +73,10 @@ final class RestoreImageDownload {
                 
         func updateDownloadProgress() {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                guard self?.downloading == true else {
+                    return
+                }
+                
                 let progressString: String
                 
                 if let byteCompletedCount = downloadTask.progress.userInfo[ProgressUserInfoKey("NSProgressByteCompletedCountKey")] as? Int,
@@ -64,49 +84,55 @@ final class RestoreImageDownload {
                 {
                     let mbCompleted = byteCompletedCount / (1024 * 1024)
                     let mbTotal     = byteTotalCount / (1024 * 1024)
-                    progressString = "Restore Image\nDownloading \(Int(downloadTask.progress.fractionCompleted * 100))% (\(mbCompleted) of \(mbTotal) MB)"
+                    progressString = "\(Int(downloadTask.progress.fractionCompleted * 100))% (\(mbCompleted) of \(mbTotal) MB)"
                 } else {
-                    progressString = "Restore Image\nDownloading \(Int(downloadTask.progress.fractionCompleted * 100))%"
+                    progressString = "\(Int(downloadTask.progress.fractionCompleted * 100))%"
                 }
-                Logger.shared.log(level: .default, "\(progressString)")
+                Logger.shared.log(level: .debug, "download progress: \(progressString)")
                 
-                self?.delegate?.progress(downloadTask.progress.fractionCompleted, progressString: progressString)
+                self?.delegate?.progress(downloadTask.progress.fractionCompleted,
+                                         progressString: "Restore Image: \(restoreImage.operatingSystemVersionString)\nDownloading \(progressString)")
 
-                if let downloading = self?.downloading, downloading {
-                    updateDownloadProgress()
-                }
+                // continue updating
+                updateDownloadProgress()
             }
         }
         
         updateDownloadProgress()
     }
     
-    fileprivate func downloadFinished(localURL: URL?, error: Error?) {
+    fileprivate func downloadFinished(tempURL: URL?, restoreImageURL: URL?, error: Error?) {
         Logger.shared.log(level: .default, "download finished")
-        delegate?.progress(100, progressString: "Done")
         
-        if let error = error {
-            Logger.shared.log(level: .default, "\(error.localizedDescription)")
-            delegate?.done(error: error)
+        if let error {
+            Logger.shared.error("\(error.localizedDescription)")
+            progressDone(error: error)
         }
         
-        if let localURL = localURL,
-           let vmFilesDirectoryString = UserDefaults.standard.vmFilesDirectory
-        {
-            let restoreImageURL = createRestoreImageURL(vmFilesDirectoryString: vmFilesDirectoryString)
-            try? FileManager.default.moveItem(at: localURL, to: restoreImageURL)
-            Logger.shared.log(level: .default, "moved restore image to \(restoreImageURL)")
-            delegate?.done(error: nil)
+        let moveError = RestoreError(localizedDescription: "Failed to prepare downloaded restore image")
+        
+        if let tempURL, let restoreImageURL {
+            Logger.shared.log(level: .debug, "moving restore image: \(tempURL) to \(restoreImageURL)")
+            delegate?.progress(99, progressString: "Preparing file. Please wait...")
+            
+            do {
+                try FileManager.default.moveItem(at: tempURL, to: restoreImageURL)
+                Logger.shared.log(level: .default, "moved restore image to \(restoreImageURL)")
+                
+                progressDone(error: nil)
+            } catch {
+                Logger.shared.log(level: .error, "failed to prepare restore image: \(error.localizedDescription)")
+                progressDone(error: moveError)
+            }
         } else {
-            Logger.shared.log(level: .default, "failed to move downloaded restore image to vm files directory")
-            delegate?.done(error: RestoreError(localizedDescription: "Failed to move downloaded restore image to VM files directory"))
-            return
+            Logger.shared.log(level: .error, "failed to prepare downloaded restore image ")
+            progressDone(error: moveError)
         }
     }
     
-    fileprivate func createRestoreImageURL(vmFilesDirectoryString: String) -> URL {
+    fileprivate func createRestoreImageURL(directoryString: String) -> URL {
         // try to find a filename that does not exist
-        var url = URL(fileURLWithPath: vmFilesDirectoryString)
+        var url = URL(fileURLWithPath: directoryString)
         var exists = true
         var i = 1
         while exists {
@@ -121,17 +147,16 @@ final class RestoreImageDownload {
     }
     
     fileprivate func nextURL(_ url: URL, _ i: Int) -> URL {
-        var filename = url.lastPathComponent
-        filename = filename.replacingOccurrences(of: ".ipsw", with: "")
-        
-        let filenameComponents = filename.split(separator: "_")
-        if filenameComponents.count > 0 {
-            filename = String(filenameComponents[0])
+        // ensure we're working with the directory, not a file
+        var directoryURL = url
+        if !url.hasDirectoryPath {
+            directoryURL = url.deletingLastPathComponent()
         }
-        filename += "_\(i).ipsw"
         
-        let path = url.deletingLastPathComponent().appendingPathComponent(filename, conformingTo: .bundle).path
-        return URL(fileURLWithPath: path)
+        // construct the filename
+        let filename = "RestoreImage_\(i).ipsw"
+        
+        return directoryURL.appendingPathComponent(filename)
     }
 
 }

--- a/virtualOS/VM/VMConfiguration.swift
+++ b/virtualOS/VM/VMConfiguration.swift
@@ -9,7 +9,7 @@
 #if arch(arm64)
 
 import Virtualization
-import AVFoundation // for audio
+import AVFoundation // for microphone support
 import OSLog
 
 final class VMConfiguration: VZVirtualMachineConfiguration {
@@ -103,11 +103,25 @@ final class VMConfiguration: VZVirtualMachineConfiguration {
     }
     
     fileprivate func configureNetworkDevices(parameters: VMParameters) {
-        let networkDevice = VZVirtioNetworkDeviceConfiguration()
-        let networkAttachment = VZNATNetworkDeviceAttachment()
-        networkDevice.attachment = networkAttachment
-        networkDevice.macAddress = VZMACAddress(string: parameters.macAddress) ?? .randomLocallyAdministered()
-        networkDevices = [networkDevice]
+        let networkDeviceConfiguration = VZVirtioNetworkDeviceConfiguration()
+        if parameters.networkType == .Bridge {
+            for interface in VZBridgedNetworkInterface.networkInterfaces {
+                if interface.description == parameters.networkBridge {
+                    networkDeviceConfiguration.attachment = VZBridgedNetworkDeviceAttachment(interface: interface)
+                }
+            }
+            
+            if networkDeviceConfiguration.attachment == nil,
+               let defaultInterface = VZBridgedNetworkInterface.networkInterfaces.first
+            {
+                networkDeviceConfiguration.attachment = VZBridgedNetworkDeviceAttachment(interface: defaultInterface)
+            }
+        } else {
+            networkDeviceConfiguration.attachment = VZNATNetworkDeviceAttachment()
+        }
+        
+        networkDeviceConfiguration.macAddress = VZMACAddress(string: parameters.macAddress) ?? .randomLocallyAdministered()
+        networkDevices = [networkDeviceConfiguration]
     }
 
     fileprivate func configureSharedFolder(parameters: VMParameters) {

--- a/virtualOS/VM/VMParameters.swift
+++ b/virtualOS/VM/VMParameters.swift
@@ -23,9 +23,11 @@ struct VMParameters: Codable {
     var screenWidth = 1500
     var screenHeight = 900
     var pixelsPerInch = 250
-    var microphoneEnabled = false
+    var microphoneEnabled = true
     var sharedFolderURL: URL?
     var sharedFolderData: Data?
+    var networkType: NetworkType?
+    var networkBridge: String?
     var macAddress = VZMACAddress.randomLocallyAdministered().string
     var version = ""
     
@@ -47,6 +49,8 @@ struct VMParameters: Codable {
         microphoneEnabled = try container.decode(Bool.self, forKey: .microphoneEnabled)
         sharedFolderURL   = try container.decodeIfPresent(URL.self, forKey: .sharedFolderURL) ?? nil // optional
         sharedFolderData  = try container.decodeIfPresent(Data.self, forKey: .sharedFolderData) ?? nil // optional
+        networkType       = try container.decodeIfPresent(NetworkType.self, forKey: .networkType) ?? NetworkType.NAT 
+        networkBridge     = try container.decodeIfPresent(String.self, forKey: .networkBridge) ?? "" // optional
         macAddress        = try container.decodeIfPresent(String.self, forKey: .macAddress) ?? VZMACAddress.randomLocallyAdministered().string // optional
         version           = try container.decodeIfPresent(String.self, forKey: .version) ?? "" // optional
 

--- a/virtualOS/ViewController/MainViewController.swift
+++ b/virtualOS/ViewController/MainViewController.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import Virtualization
+import AVFoundation // for microphone support
 import OSLog
 
 #if arch(arm64)
@@ -23,6 +24,9 @@ final class MainViewController: NSViewController {
     @IBOutlet weak var cpuCountSlider: NSSlider!
     @IBOutlet weak var ramLabel: NSTextField!
     @IBOutlet weak var ramSlider: NSSlider!
+    @IBOutlet weak var microphoneSwitch: NSSwitch!
+    @IBOutlet weak var networkPopUpButton: NSPopUpButton!
+    @IBOutlet weak var networkBridgePopUpButton: NSPopUpButton!
     
     fileprivate let mainStoryBoard = NSStoryboard(name: "Main", bundle: nil)
     fileprivate let viewModel = MainViewModel()
@@ -30,22 +34,23 @@ final class MainViewController: NSViewController {
     fileprivate var windowController: WindowController? {
         return view.window?.windowController as? WindowController
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        view.window?.delegate           = self
         tableView.dataSource            = viewModel.tableViewDataSource
         tableView.delegate              = self
         parameterOutlineView.dataSource = viewModel.parametersViewDataSource
         parameterOutlineView.delegate   = viewModel.parametersViewDelegate
         vmNameTextField.delegate        = viewModel.textFieldDelegate
-
+        
         NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: NSApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: NSControl.textDidEndEditingNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: Constants.didChangeVMLocationNotification, object: nil)
         
         NotificationCenter.default.addObserver(self, selector: #selector(restoreImageSelected), name: Constants.restoreImageNameSelectedNotification, object: nil)
-
+        
         ramSlider.target = self
         ramSlider.action = #selector(memorySliderChanged(sender:))
         cpuCountSlider.target = self
@@ -58,13 +63,18 @@ final class MainViewController: NSViewController {
     
     override func viewWillAppear() {
         super.viewWillAppear()
-        
-        view.window?.delegate = self
         windowController?.mainViewController = self
         vmNameTextField.resignFirstResponder()
         startAccessToVMFilesDirectory()
         FileModel.cleanUpTemporaryFiles()
         updateUI()
+    }
+    
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        if viewModel.vmParameters?.microphoneEnabled == true {
+            checkMicrophonePermission()
+        }
     }
     
     @IBAction func startButtonPressed(_ sender: NSButton) {
@@ -103,16 +113,16 @@ final class MainViewController: NSViewController {
         let alert: NSAlert = NSAlert.okCancelAlert(messageText: "Delete VM '\(vmBundle.name)'?", informativeText: "This can not be undone.", alertStyle: .warning)
         let selection = alert.runModal()
         if selection == NSApplication.ModalResponse.alertFirstButtonReturn ||
-           selection == NSApplication.ModalResponse.OK
+            selection == NSApplication.ModalResponse.OK
         {
             viewModel.deleteVM(selection: selection, vmBundle: vmBundle)
             viewModel.vmBundle = nil
             viewModel.vmParameters = nil
         }
-
+        
         self.updateUI()
     }
-        
+    
     @IBAction func sharedFolderButtonPressed(_ sender: Any) {
         let openPanel = NSOpenPanel()
         openPanel.allowsMultipleSelection = false
@@ -142,17 +152,17 @@ final class MainViewController: NSViewController {
                 let accessoryView = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 20))
                 accessoryView.stringValue = "\(UserDefaults.standard.diskSize)"
                 
-                let alert = NSAlert.okCancelAlert(messageText: "Disk Image Size in GB", informativeText: "Disk size can not be changed after VM is created. Minimum disk size is 30 GB. During install, a lot of RAM is used, ignore the warning about low system memory.", accessoryView: accessoryView)
+                let alert = NSAlert.okCancelAlert(messageText: "Disk Image Size in GB", informativeText: "Disk size can not be changed after VM is created. Minimum disk size is 30 GB.", accessoryView: accessoryView)
                 let modalResponse = alert.runModal()
                 accessoryView.becomeFirstResponder()
-
+                
                 if modalResponse == .OK || modalResponse == .alertFirstButtonReturn  {
                     diskImageSize = Int(accessoryView.intValue)
                 } else {
                     return // cancel install
                 }
-                if diskImageSize < 30 {
-                    self.diskImageSize = 30
+                if diskImageSize < Constants.defaultDiskImageSize {
+                    self.diskImageSize = Constants.defaultDiskImageSize
                 }
             }
             
@@ -167,7 +177,32 @@ final class MainViewController: NSViewController {
     @objc func memorySliderChanged(sender: NSSlider) {
         updateUIAndStoreParametersToDisk()
     }
+    
+    @IBAction func microphoneSwitchToggled(_ sender: NSSwitch) {
+        if sender.state == .on {
+            checkMicrophonePermission()
+        }
+        viewModel.vmParameters?.microphoneEnabled = sender.state == .on
+        viewModel.storeParametersToDisk()
+    }
+    
+    @IBAction func networkPopUpChanged(_ sender: NSPopUpButton) {
+        var networkType = NetworkType.NAT
+        if sender.selectedItem?.title == NetworkType.Bridge.rawValue {
+            networkType = .Bridge
+        }
         
+        updateBridges()
+        viewModel.vmParameters?.networkType = networkType
+        viewModel.storeParametersToDisk()
+        updateUI()
+    }
+    
+    @IBAction func networkBridgeInterfacePopUpChanged(_ sender: NSPopUpButton) {
+        viewModel.vmParameters?.networkBridge = sender.selectedItem?.title
+        viewModel.storeParametersToDisk()
+    }
+    
     @objc func updateUI() {
         self.tableView.reloadData()
         
@@ -190,7 +225,8 @@ final class MainViewController: NSViewController {
                 updateLabels(setZero: false)
                 updateCpuCount(vmParameters)
                 updateRam(vmParameters)
-                updateEnabledState(enabled: true)
+                updateNetwork(vmParameters)
+                updateEnabledState(enabled: true, vmParameters: vmParameters)
             }
         } else {
             vmNameTextField.stringValue = "No virtual machine available. Press install to add one."
@@ -198,8 +234,27 @@ final class MainViewController: NSViewController {
             updateLabels(setZero: true)
             updateEnabledState(enabled: false)
         }
-
+        
+        updateBridges()
         updateOutlineView()
+    }
+    
+    fileprivate func updateBridges() {
+        networkBridgePopUpButton.removeAllItems()
+        var i = 0
+        let selectedBridge = viewModel.vmParameters?.networkBridge
+        for interface in VZBridgedNetworkInterface.networkInterfaces {
+            networkBridgePopUpButton.insertItem(withTitle: interface.description, at: i)
+            i += 1
+            if selectedBridge == interface.description {
+                networkBridgePopUpButton.selectItem(at: i)
+                viewModel.vmParameters?.networkBridge = interface.description
+            }
+        }
+        
+        if networkBridgePopUpButton.selectedItem == nil {
+            networkBridgePopUpButton.selectItem(at: 0)
+        }
     }
     
     func showErrorAlert(error: Error) {
@@ -221,7 +276,7 @@ final class MainViewController: NSViewController {
         } else {
             informativeText = error.localizedDescription
         }
-
+        
         Logger.shared.log(level: .default, "\(messageText) \(informativeText)")
         let alert = NSAlert.okCancelAlert(messageText: messageText, informativeText: informativeText, showCancelButton: false)
         let _ = alert.runModal()
@@ -229,13 +284,18 @@ final class MainViewController: NSViewController {
     
     // MARK: - Private
     
-    fileprivate func updateEnabledState(enabled: Bool) {
-        ramSlider.isEnabled       = enabled
-        cpuCountSlider.isEnabled  = enabled
-        vmNameTextField.isEnabled = enabled
+    fileprivate func updateEnabledState(enabled: Bool, vmParameters: VMParameters? = nil) {
+        ramSlider.isEnabled        = enabled
+        cpuCountSlider.isEnabled   = enabled
+        vmNameTextField.isEnabled  = enabled
+        if vmParameters?.microphoneEnabled ?? false {
+            microphoneSwitch.state = .on
+        } else {
+            microphoneSwitch.state = .off
+        }
         windowController?.updateButtons(hidden: !enabled)
     }
-
+    
     fileprivate func updateCpuCount(_ vmParameters: VMParameters) {
         cpuCountSlider.minValue = Double(vmParameters.cpuCountMin)
         cpuCountSlider.maxValue = Double(vmParameters.cpuCountMax)
@@ -250,6 +310,23 @@ final class MainViewController: NSViewController {
         ramSlider.numberOfTickMarks = Int(ramSlider.maxValue - ramSlider.minValue)
         ramSlider.doubleValue = Double(vmParameters.memorySizeInGB)
         ramSlider.isEnabled = true
+    }
+    
+    fileprivate func updateNetwork(_ vmParameters: VMParameters) {
+        switch vmParameters.networkType {
+        case .NAT:
+            networkPopUpButton.selectItem(at: 0)
+        case .Bridge:
+            networkPopUpButton.selectItem(at: 1)
+        default:
+            networkPopUpButton.selectItem(at: 0)
+        }
+        
+        if vmParameters.networkType == .NAT {
+            networkBridgePopUpButton.isHidden = true
+        } else {
+            networkBridgePopUpButton.isHidden = false
+        }
     }
     
     fileprivate func updateLabels(setZero: Bool) {
@@ -274,9 +351,8 @@ final class MainViewController: NSViewController {
     fileprivate func updateUIAndStoreParametersToDisk() {
         viewModel.storeParametersToDisk()
         updateLabels(setZero: false)
-        updateOutlineView()
     }
-
+    
     fileprivate func showSheet(mode: ProgressViewController.Mode, restoreImageName: String?, diskImageSize: Int?)  {
         if let progressWindowController = mainStoryBoard.instantiateController(withIdentifier: "ProgressWindowController") as? NSWindowController,
            let progressWindow = progressWindowController.window
@@ -292,6 +368,22 @@ final class MainViewController: NSViewController {
         }
     }
     
+    fileprivate func checkMicrophonePermission() {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            Logger.shared.log(level: .default, "audio support in the vm is enabled: \(granted)")
+            if !granted {
+                DispatchQueue.main.async { [weak self] in
+                    let alert = NSAlert.okCancelAlert(messageText: "Microphone Permission", informativeText: "Please allow microphone access in System Settings → Privacy → Camera and Microphone to use audio input in the virtual machine.", showCancelButton: false)
+                    let _ = alert.runModal()
+                    self?.microphoneSwitch.state = .off
+                    self?.viewModel.vmParameters?.microphoneEnabled = false
+                    self?.viewModel.storeParametersToDisk()
+                }
+            }
+        }
+    }
+    
+    
     fileprivate func startAccessToVMFilesDirectory() {
         if let bookmarkURL = UserDefaults.standard.vmFilesDirectory?.removingPercentEncoding,
            let bookmarkData = UserDefaults.standard.vmFilesDirectoryBookmarkData
@@ -302,7 +394,6 @@ final class MainViewController: NSViewController {
             }
         }
     }
-
 }
 
 extension MainViewController: NSTableViewDelegate {
@@ -310,7 +401,7 @@ extension MainViewController: NSTableViewDelegate {
         var row: Int? = nil
         
         if let userInfo = notification.userInfo,
-            let indexSet = userInfo["NSTableViewCurrentRowSelectionUserInfoKey"] as? NSIndexSet {
+           let indexSet = userInfo["NSTableViewCurrentRowSelectionUserInfoKey"] as? NSIndexSet {
             if indexSet.count > 0 {
                 row = indexSet.firstIndex
             }
@@ -328,7 +419,7 @@ extension MainViewController: NSWindowDelegate  {
         let alert: NSAlert = NSAlert.okCancelAlert(messageText: "Quit", informativeText: "Quitting the app will stop all virtual machines.", alertStyle: .warning)
         let selection = alert.runModal()
         if selection == NSApplication.ModalResponse.alertFirstButtonReturn ||
-           selection == NSApplication.ModalResponse.OK
+            selection == NSApplication.ModalResponse.OK
         {
             NSApplication.shared.terminate(self)
             return true
@@ -352,7 +443,7 @@ final class MainViewController: NSViewController {
     @IBOutlet weak var cpuCountSlider: NSSlider!
     @IBOutlet weak var ramLabel: NSTextField!
     @IBOutlet weak var ramSlider: NSSlider!
-
+    
     override func viewWillAppear() {
         super.viewWillAppear()
         vmNameTextField.stringValue = "Virtualization requires an Apple Silicon machine"

--- a/virtualOS/ViewController/MainViewController.swift
+++ b/virtualOS/ViewController/MainViewController.swift
@@ -47,7 +47,8 @@ final class MainViewController: NSViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: NSApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: NSControl.textDidEndEditingNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateUI), name: Constants.didChangeVMLocationNotification, object: nil)
+        NotificationCenter.default
+            .addObserver(self, selector: #selector(updateUI), name: Constants.didChangeAppSettingsNotification, object: nil)
         
         NotificationCenter.default.addObserver(self, selector: #selector(restoreImageSelected), name: Constants.restoreImageNameSelectedNotification, object: nil)
         
@@ -152,7 +153,11 @@ final class MainViewController: NSViewController {
                 let accessoryView = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 20))
                 accessoryView.stringValue = "\(UserDefaults.standard.diskSize)"
                 
-                let alert = NSAlert.okCancelAlert(messageText: "Disk Image Size in GB", informativeText: "Disk size can not be changed after VM is created. Minimum disk size is 30 GB.", accessoryView: accessoryView)
+                let alert = NSAlert.okCancelAlert(
+                    messageText: "Disk Image Size in GB",
+                    informativeText: "Disk size can not be changed after VM is created. Minimum disk size is \(Constants.defaultDiskImageSize) GB.",
+                    accessoryView: accessoryView
+                )
                 let modalResponse = alert.runModal()
                 accessoryView.becomeFirstResponder()
                 

--- a/virtualOS/ViewController/ProgressViewController.swift
+++ b/virtualOS/ViewController/ProgressViewController.swift
@@ -28,6 +28,8 @@ final class ProgressViewController: NSViewController {
     fileprivate var restoreImageInstall = RestoreImageInstall()
     
     override func viewDidLoad() {
+        super.viewDidLoad()
+        
         progressIndicator.doubleValue = 0
         statusTextField.stringValue = "Starting"
         statusTextField.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
@@ -73,33 +75,27 @@ final class ProgressViewController: NSViewController {
 
 extension ProgressViewController: ProgressDelegate {
     func progress(_ progress: Double, progressString: String) {
-        func updateUI() {
-            progressIndicator.doubleValue = progress * 100
-            statusTextField.stringValue = progressString
-        }
-        
-        if Thread.isMainThread {
-            updateUI()
-        } else {
-            DispatchQueue.main.async {
-                updateUI()
-            }
+        DispatchQueue.main.async { [weak self] in
+            self?.progressIndicator.doubleValue = progress * 100
+            self?.statusTextField.stringValue = progressString
         }
     }
     
     func done(error: Error? = nil) {
         DispatchQueue.main.async { [weak self] in
-            if let mainViewController = self?.presentingViewController as? MainViewController {
-                mainViewController.dismiss(self)
-                mainViewController.updateUI()
-                
-                if let error = error {
-                    mainViewController.showErrorAlert(error: error)
-                    self?.statusTextField.stringValue = "Install Failed."
-                    self?.cancelButton.title = "Close"
-                } else {
-                    self?.cancelButton.title = "Done"
-                }
+            guard let mainViewController = self?.presentingViewController as? MainViewController else {
+                return
+            }
+        
+            mainViewController.dismiss(self)
+            mainViewController.updateUI()
+            
+            if let error = error {
+                mainViewController.showErrorAlert(error: error)
+                self?.statusTextField.stringValue = "Install Failed."
+                self?.cancelButton.title = "Close"
+            } else {
+                self?.cancelButton.title = "Done"
             }
         }
     }

--- a/virtualOS/ViewController/SettingsViewController.swift
+++ b/virtualOS/ViewController/SettingsViewController.swift
@@ -9,62 +9,115 @@
 import AppKit
 import OSLog
 
+fileprivate enum SettingTag: Int {
+    case vmFilesDirectory = 1
+    case restoreImagesDirectory = 2
+}
+
 final class SettingsViewController: NSViewController {
     @IBOutlet weak var vmFilesURLLabel: NSTextField!
+    @IBOutlet weak var restoreImageFilesURLLabel: NSTextField!
     
     override func viewWillAppear() {
-        updateVMFilesLabel()
+        super.viewWillAppear()
+        
+        updateSettingsLabels()
+        configureWindow()
     }
-
-    @IBAction func selectFolderButtonPressed(_ sender: Any) {
+    
+    @IBAction func selectFolderButtonPressed(_ sender: NSButton) {
         let openPanel = NSOpenPanel()
         openPanel.allowsMultipleSelection = false
         openPanel.canChooseDirectories = true
         openPanel.canChooseFiles = false
-        openPanel.prompt = "Select"
+        openPanel.prompt = "Select Folder"
         let modalResponse = openPanel.runModal()
         
         guard modalResponse == .OK,
-           let vmFilesURL = openPanel.url else
+           let selectedURL = openPanel.url else
         {
             return
         }
         
-        let vmFilesPath = vmFilesURL.path(percentEncoded: false)
-        if let bookmarkData = Bookmark.createBookmarkData(fromUrl: vmFilesURL),
-           Bookmark.startAccess(bookmarkData: bookmarkData, for: vmFilesPath) != nil
-        {
-            UserDefaults.standard.vmFilesDirectory = vmFilesPath
-            UserDefaults.standard.vmFilesDirectoryBookmarkData = bookmarkData
-            postNotification()
-        } else {
-            Logger.shared.log("Could not create or start accessing bookmark \(vmFilesURL.path)")
+        let selectedPath = selectedURL.path(percentEncoded: false)
+        
+        guard let bookmarkData = Bookmark.createBookmarkData(fromUrl: selectedURL),
+           Bookmark.startAccess(bookmarkData: bookmarkData, for: selectedPath) != nil else {
+            Logger.shared.log("Could not create or start accessing bookmark \(selectedURL.path)")
+            return
         }
+        
+        switch SettingTag(rawValue: sender.tag) {
+        case .vmFilesDirectory:
+            UserDefaults.standard.vmFilesDirectory = selectedPath
+            UserDefaults.standard.vmFilesDirectoryBookmarkData = bookmarkData
+        case .restoreImagesDirectory:
+            UserDefaults.standard.restoreImagesDirectory = selectedPath
+            UserDefaults.standard.restoreImagesDirectoryBookmarkData = bookmarkData
+        default:
+            fatalError("bad setting tag")
+        }
+        
+        postNotification()
     }
     
     @IBAction func resetButtonPressed(_ sender: Any) {
         UserDefaults.standard.vmFilesDirectory = nil
         UserDefaults.standard.vmFilesDirectoryBookmarkData = nil
+        
+        UserDefaults.standard.restoreImagesDirectory = nil
+        UserDefaults.standard.restoreImagesDirectoryBookmarkData = nil
+        
         postNotification()
     }
     
-    @IBAction func showInFinderButtonPressed(_ sender: Any) {
+    @IBAction func showInFinderButtonPressed(_ sender: NSButton) {
         var url: URL
-        if let hardDiskDirectoryString = UserDefaults.standard.vmFilesDirectory {
-            url = URL(fileURLWithPath: hardDiskDirectoryString)
-        } else {
-            url = URL.baseURL
+        
+        switch SettingTag(rawValue: sender.tag) {
+        case .vmFilesDirectory:
+            if let directoryString = UserDefaults.standard.vmFilesDirectory {
+                url = URL(fileURLWithPath: directoryString)
+            } else {
+                url = URL.baseURL
+            }
+        case .restoreImagesDirectory:
+            if let directoryString = UserDefaults.standard.restoreImagesDirectory {
+                url = URL(fileURLWithPath: directoryString)
+            } else {
+                url = URL.defaultRestoreImageURL
+            }
+        default:
+            fatalError("bad setting tag")
         }
+        
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
     
-    fileprivate func updateVMFilesLabel() {
+    fileprivate func configureWindow() {
+        guard let window = view.window else {
+            return
+        }
+        
+        // prevent window from being resizable
+        window.styleMask.remove(.resizable)
+        
+        // set fixed size
+        let contentSize = view.frame.size
+        window.setContentSize(contentSize)
+        window.minSize = contentSize
+        window.maxSize = contentSize
+    }
+    
+    fileprivate func updateSettingsLabels() {
         let vmFilesDirectory = FileModel.createVMFilesDirectory()
-        vmFilesURLLabel.stringValue = "Storing VM files at:\n\(vmFilesDirectory.path)"
+        
+        restoreImageFilesURLLabel.stringValue = UserDefaults.standard.restoreImagesDirectory ?? vmFilesDirectory.path
+        vmFilesURLLabel.stringValue = vmFilesDirectory.path
     }
     
     fileprivate func postNotification() {
-        updateVMFilesLabel()
-        NotificationCenter.default.post(name: Constants.didChangeVMLocationNotification, object: nil)
+        updateSettingsLabels()
+        NotificationCenter.default.post(name: Constants.didChangeAppSettingsNotification, object: nil)
     }
 }


### PR DESCRIPTION
This PR will add a few more features:
- Allow the user to select the restore image directory
- Improved Settings UI
- Enhanced restore image download experience

Settings screenshot:
<img width="601" height="357" alt="Screenshot 2025-10-16 at 7 49 16 PM" src="https://github.com/user-attachments/assets/11991457-66af-4a6f-b31b-a5446d333024" />

I performed several tests on the custom directories:
- External drive VM does **not** work. I get various errors.
- External drive for restore images works as expected
  - Apple logic downloads to device, then app moves the file to the external drive.
  - Installs VM from external drive as expected, but VM must install on device.

I used VM images from: https://ipsw.me/VirtualMac2,1

Replaces #49 